### PR TITLE
Add icon to Chart.yml for happa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add icon to Chart.yml for use in happa
+
 ## [1.0.1] - 2022-03-15
 
 ### Added

--- a/helm/vertical-pod-autoscaler-crd/Chart.yaml
+++ b/helm/vertical-pod-autoscaler-crd/Chart.yaml
@@ -2,6 +2,7 @@ apiVersion: v2
 appVersion: 0.9.2
 name: vertical-pod-autoscaler-crd
 description: Vertical Pod Autoscaler CustomResourceDefinitions.
+icon: https://s.giantswarm.io/app-icons/k8s-initiator/1/dark.svg
 home: https://github.com/giantswarm/vertical-pod-autoscaler-crd
 sources:
 - https://github.com/kubernetes/autoscaler


### PR DESCRIPTION
For https://github.com/giantswarm/roadmap/issues/1248

Don't be confused by `k8s-initiator`. We are reusing existing icons and that is just the Kubernetes icon.