### PR TITLE
Remove push-to-capa

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,19 +88,3 @@ workflows:
               ignore: /.*/
             tags:
               only: /^v.*/
-
-      - architect/push-to-app-collection:
-          context: architect
-          name: push-to-capa-app-collection
-          app_catalog: control-plane-catalog
-          app_name: vertical-pod-autoscaler-crd
-          app_namespace: giantswarm
-          app_collection_repo: "capa-app-collection"
-          disable_force_upgrade: true
-          requires:
-            - control-plane-catalog
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/


### PR DESCRIPTION
Vertical-pod-autoscaler-crd is a part of default-apps-aws so it should not be pushed to capa collections